### PR TITLE
Fix #18 - Update Haskell instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,18 +111,10 @@ For completions to work make sure the version of `metals` has [this bug fix][met
 
 # Haskell
 
-Currently haskell-ide-engine always completes snippets, which trips up ycmd.
-The [pull request][hie-pr] that fixed this bug has already been merged, but isn't
-available in version 0.13.0.0. Until the next version of HIE compile its git master.
+haskell-ide-engine [is not actively being developed anymore][hie-not-developing], in
+favour of [haskell-language-server][haskell-language-server] ([installation
+instructions][hls-install]).
 
-The HIE install instructions can be found [here][hie-install].
-
-HIE also requires a `.ycm_extra_config.py` with the following content:
-
-```python
-def Settings(**kwargs):
-  return { 'ls': { "languageServerHaskell": {} } }
-```
 
 # Fortran
 
@@ -291,3 +283,6 @@ following makes json work with that fork:
 [metals-pr]: https://github.com/scalameta/metals/issues/1057
 [lua-language-server]: https://marketplace.visualstudio.com/items?itemName=sumneko.lua
 [puremourning-fork]: https://github.com/puremourning/YouCompleteMe
+[hie-not-developing]: https://stackoverflow.com/questions/64087188/what-is-the-current-situation-for-using-vim-as-ide-for-haskell-on-archlinux/
+[haskell-language-server]: https://github.com/haskell/haskell-language-server
+[hls-install]: https://github.com/haskell/haskell-language-server#installation

--- a/haskell/snippet.vim
+++ b/haskell/snippet.vim
@@ -1,7 +1,8 @@
 let g:ycm_language_server += [
-  \   { 'name': 'haskell',
-  \     'filetypes': [ 'haskell', 'hs', 'lhs' ],
-  \     'cmdline': [ 'hie-wrapper', '--lsp' ],
-  \     'project_root_files': [ '.stack.yaml', 'cabal.config', 'package.yaml' ]
+  \   {
+  \     'name': 'haskell-language-server',
+  \     'cmdline': [ 'haskell-language-server-wrapper', '--lsp' ],
+  \     'filetypes': [ 'haskell', 'lhaskell' ],
+  \     'project_root_files': [ 'stack.yaml', 'cabal.project', 'package.yaml', 'hie.yaml' ],
   \   },
   \ ]


### PR DESCRIPTION
I have installed it on my Arch system from the [AUR](https://aur.archlinux.org/packages/haskell-language-server-bin/#news), but I don't think this is relevant to this PR, right?

However, please, let me know if you think of a better wording, or that mentioning haskell-ide-engine it's now useless since it's been declared as unmaintained by the author.


By the way, everything seems to work out of the box, in the sense that I can see the difference between before and after installing the server and putting that setting in my vimrc; after doing so, I do see function signatures of some functions.

Since (as I understand) from YCM's perspective, Haskell semantic completion either works or doesn't work uniquely depending on haskell language server, I guess there's nothing else I need to know to create this PR, even for now I don't see that semantic completion very helpful, maybe because I haven't understood how it is supposed to work.

Any observations are welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/lsp-examples/19)
<!-- Reviewable:end -->
