### PR TITLE
Use ` g:ycm_lsp_dir` instead of `s:lsp`

### DIFF
--- a/cmake/snippet.vim
+++ b/cmake/snippet.vim
@@ -6,7 +6,7 @@ end
 let g:ycm_language_server += [
   \   {
   \     'name': 'cmake',
-  \     'cmdline': [ expand( s:lsp . '/cmake/venv/' . s:pip_os_dir . '/cmake-language-server' )],
+  \     'cmdline': [ expand( g:ycm_lsp_dir . '/cmake/venv/' . s:pip_os_dir . '/cmake-language-server' )],
   \     'filetypes': [ 'cmake' ],
   \    },
   \ ]


### PR DESCRIPTION
When run vim + lsp-example under macOS, the following message will be shown
``` text
line   15:
E121: Undefined variable: s:lsp
E116: Invalid arguments for function expand( s:lsp . '/cmake/venv/' . s:pip_os_dir . '/cmake-language-server' )],     'filetypes': [ 'cmake' ],    }, ]
Press ENTER or type command to continue
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/lsp-examples/24)
<!-- Reviewable:end -->
