### PR TITLE
dart: Remove dartfmt requirement

### DIFF
--- a/dart/install.py
+++ b/dart/install.py
@@ -34,8 +34,8 @@ def FindExecutable( executable ):
       return executable_name
   return None
 
-if not FindExecutable( 'dart' ) or not FindExecutable( 'dartfmt' ):
-  raise UserWarning( '`dart` and `dartfmt` are needed in $PATH for proper operation' )
+if not FindExecutable( 'dart' ):
+  raise UserWarning( '`dart` is needed in $PATH for proper operation' )
 
 ARCHIVE_URL = 'https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-{}-{}-release.zip'
 IS_64BIT = sys.maxsize > 2**32


### PR DESCRIPTION
This is being deprecated and replaced by "dart format".

https://github.com/ycm-core/lsp-examples/issues/28

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/lsp-examples/29)
<!-- Reviewable:end -->
