### PR TITLE
Update Fortran Language Server to fortls

### DIFF
--- a/fortran/install.py
+++ b/fortran/install.py
@@ -54,7 +54,7 @@ def Main():
                            'install',
                            '--user',
                            '--upgrade',
-                           'fortran-language-server' ] )
+                           'fortls' ] )
 
 
 if __name__ == '__main__':

--- a/fortran/snippet.vim
+++ b/fortran/snippet.vim
@@ -1,6 +1,6 @@
 let g:ycm_language_server += [
   \   { 'name': 'fortran',
   \     'filetypes': [ 'fortran' ],
-  \     'cmdline': [ 'fortls' ],
+  \     'cmdline': [ 'fortls', '--notify_init', '--hover_signature', '--hover_language', 'fortran', '--use_signature_help' ],
   \   },
   \ ]


### PR DESCRIPTION
I am in the process of updating the links to the Fortran Language Server, the original `fortran-language-server` has been abandoned for ~2y now so `fortls`: https://github.com/gnikit/fortls is meant as a minimally invasive replacement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/lsp-examples/32)
<!-- Reviewable:end -->
