### PR TITLE
fix scala langauge server command name

### DIFF
--- a/scala/snippet.vim
+++ b/scala/snippet.vim
@@ -1,7 +1,7 @@
 let g:ycm_language_server += [
   \   { 'name': 'scala',
   \     'filetypes': [ 'scala' ],
-  \     'cmdline': [ 'metals-vim' ],
+  \     'cmdline': [ 'metals' ],
   \     'project_root_files': [ 'build.sbt' ]
   \   },
   \ ]


### PR DESCRIPTION
When using `\     'cmdline': [ 'metals-vim' ],` I received the following error:
```
ValueError: No semantic completer exists for filetypes: ['scala']
```
The command which starts the language server is called `metals`. I changed it and now I can successfully connect to the metals server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/lsp-examples/38)
<!-- Reviewable:end -->
