### PR TITLE
Update for new version of Dart

### DIFF
--- a/dart/install.py
+++ b/dart/install.py
@@ -2,11 +2,6 @@
 
 import os
 import platform
-import shutil
-import sys
-import tempfile
-import urllib.request
-import zipfile
 
 
 # On Windows, distutils.spawn.find_executable only works for .exe files
@@ -19,7 +14,7 @@ def FindExecutable( executable ):
   paths = os.environ[ 'PATH' ].split( os.pathsep )
   base, extension = os.path.splitext( executable )
 
-  if platform.system() == 'Windows'  and extension.lower() not in WIN_EXECUTABLE_EXTS:
+  if platform.system() == 'Windows' and extension.lower() not in WIN_EXECUTABLE_EXTS:
     extensions = WIN_EXECUTABLE_EXTS
   else:
     extensions = [ '' ]
@@ -35,38 +30,6 @@ def FindExecutable( executable ):
       return executable_name
   return None
 
+
 if not FindExecutable( 'dart' ):
   raise UserWarning( '`dart` is needed in $PATH for proper operation' )
-
-ARCHIVE_URL = 'https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-{}-{}-release.zip'
-IS_64BIT = sys.maxsize > 2**32
-
-if platform.system() == 'Windows':
-  system = 'windows'
-  arch = 'x64' if IS_64BIT else 'ia32'
-elif platform.system() == 'Darwin':
-  system = 'macos'
-  arch = 'x64'
-elif platform.system() == 'Linux':
-  system = 'linux'
-  if platform.machine().lower().startswith( 'x86_64' ):
-    arch = 'x64' if IS_64BIT else 'ia32'
-  else:
-    arch = 'arm'
-    if IS_64BIT:
-      arch += '64'
-else:
-  raise RuntimeError( 'No prebuilt archive for this operating system. Compile the SDK manually.' )
-
-
-archive_response = urllib.request.urlopen( ARCHIVE_URL.format( system, arch ) )
-with open( 'dart-sdk.zip', 'wb' ) as archive:
-  archive.write( archive_response.read() )  
-
-
-with zipfile.ZipFile( 'dart-sdk.zip', 'r' ) as dart_zip:
-  with tempfile.TemporaryDirectory() as tmp_dir:
-    # unzip to tmp_dir
-    dart_zip.extractall( tmp_dir )
-    path_to_lsp_server = os.path.join( tmp_dir, 'dart-sdk', 'bin', 'snapshots', 'analysis_server.dart.snapshot' )
-    shutil.copy( path_to_lsp_server, 'analysis_server.dart.snapshot' )

--- a/dart/snippet.vim
+++ b/dart/snippet.vim
@@ -1,7 +1,7 @@
 let g:ycm_language_server += [
   \   {
   \     'name': 'dart',
-  \     'cmdline': [ 'dart', expand( g:ycm_lsp_dir . '/dart/analysis_server.dart.snapshot' ), '--lsp' ],
+  \     'cmdline': [ 'dart', 'language-server', '--client-id', 'youcompleteme' ],
   \     'filetypes': [ 'dart' ],
   \   },
   \ ]


### PR DESCRIPTION
Since November 2021, a language server is [built-in](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md) into the dart executable. So no extra downloads necessary. One drawback is that LSP starts very slow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/lsp-examples/41)
<!-- Reviewable:end -->
