### PR TITLE
Add Erlang Language Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ composer.lock
 #add for ignoring node_modules dir
 node_modules/
 vimrc.generated
+
+## Add to ignore cloned Erlang LS source
+erlang/erlang_ls/

--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ sudo pacman -S erlang &&
 ```
 </details>
 
+> :warning: doc-comments, as of 2025-02-11, are only extracted correctly when a project includes `{project_plugins, [rebar3_ex_doc]}.`, within its `rebar.conf` file.  Check [`erlang-ls/erlang_ls` -- Issue `1578`](https://github.com/erlang-ls/erlang_ls/issues/1578) for the full scoop.
+
 # Jai
 
 This is using [Jails](https://github.comSogoCZE/Jails), which is very much

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ by YCM, though they should work for the most part.
    * [Crystal](#crystal)
    * [Astro](#astro)
    * [Postgres](#postgres)
+   * [Erlang](#erlang)
    * [Known Issues](#known-issues)
 
 <!-- Added by: ben, at: Tue 21 Feb 2023 09:01:14 GMT -->
@@ -403,6 +404,19 @@ Within the root of a project running `postgrestools init` is recommend by
 [Configuration](https://pgtools.dev/#configuration) documentation to create a
 `postgrestools.jsonc` file, then editing that file for your database setup
 seems required to make full use of this Language Server's tooling.
+
+# Erlang
+
+Be sure to have satisfied [minimum requirements](https://github.com/erlang-ls/erlang_ls?tab=readme-ov-file#minimum-requirements), and checking [configuration](https://erlang-ls.github.io/configuration/) documentation may be prudent.
+
+<details><summary>Minimum Requirements install hints</summary>
+**Arch (BTW™)**
+
+```bash
+sudo pacman -S erlang &&
+  yay -S rebar3
+```
+</details>
 
 # Jai
 

--- a/erlang/install.py
+++ b/erlang/install.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import subprocess, os, sys, platform
+
+def OnWindows():
+  return platform.system() == 'Windows'
+
+
+# On Windows, distutils.spawn.find_executable only works for .exe files
+# but .bat and .cmd files are also executables, so we use our own
+# implementation.
+def FindExecutable( executable ):
+  # Executable extensions used on Windows
+  WIN_EXECUTABLE_EXTS = [ '.exe', '.bat', '.cmd' ]
+
+  paths = os.environ[ 'PATH' ].split( os.pathsep )
+  base, extension = os.path.splitext( executable )
+
+  if OnWindows() and extension.lower() not in WIN_EXECUTABLE_EXTS:
+    extensions = WIN_EXECUTABLE_EXTS
+  else:
+    extensions = [ '' ]
+
+  for extension in extensions:
+    executable_name = executable + extension
+    if not os.path.isfile( executable_name ):
+      for path in paths:
+        executable_path = os.path.join( path, executable_name )
+        if os.path.isfile( executable_path ):
+          return executable_path
+    else:
+      return executable_name
+  return None
+
+
+def FindExecutableOrDie( executable, message ):
+  path = FindExecutable( executable )
+
+  if not path:
+    sys.exit( "ERROR: Unable to find executable '{0}'. {1}".format(
+      executable,
+      message ) )
+
+  return path
+
+
+def Main():
+  git_dir = 'erlang_ls'
+  if FindExecutable( 'erlang_ls' ) is not None and os.path.isdir(os.curdir + os.sep + git_dir) is not True:
+    sys.exit( "Error: Erlang Language Server already installed by unknown means" )
+
+  git = FindExecutableOrDie( 'git', 'git is required' )
+  make = FindExecutableOrDie( 'make', 'make is required to set up Erlang LS.' )
+
+  url = 'https://github.com/erlang-ls/erlang_ls'
+
+  if os.path.isdir(os.curdir + os.sep + git_dir):
+    print("erlang_ls already cloned into directory")
+    print("Going to update and upgrade")
+    os.chdir(git_dir)
+    subprocess.check_call( [ git, 'pull' ] )
+    subprocess.check_call( [ git, 'submodule', 'update', '--recursive' ] )
+  else:
+    subprocess.check_call( [ git, 'clone', '--recurse-submodules', '--depth=1', url ] )
+    os.chdir(git_dir)
+
+  subprocess.check_call( [ make ] )
+
+
+if __name__ == '__main__':
+  Main()

--- a/erlang/snippet.vim
+++ b/erlang/snippet.vim
@@ -1,0 +1,8 @@
+let g:ycm_language_server += [
+  \   {
+  \     'name': 'erlang',
+  \     'filetypes': [ 'erlang' ],
+  \     'cmdline': [  expand( g:ycm_lsp_dir . '/erlang/erlang_ls/_build/default/bin/erlang_ls' ), '--transport', 'stdio' ],
+  \     'project_root_files': [ 'erlang_ls.config', 'erlang_ls.yaml' ]
+  \   },
+  \ ]


### PR DESCRIPTION
Initial tests, after satisfying dependencies, seem to show a good time can be had between YouCompleteMe and Erlang Language Server!

**YCM log snippet**

```
127.0.0.1 - - [21/Jan/2025 15:40:36] "POST /debug_info HTTP/1.1" 200 332
2025-01-21 15:40:59,510 - INFO - Initializing generic LSP completer with: {'project_root_files': ['erlang_ls.config', 'erlang_ls.yaml'], 'name': 'erlang', 'cmdline': ['~/git/hub/ycm-core/lsp-examples/erlang/erlang_ls/_build/default/bin/erlang_ls', '--transport', 'stdio'], 'filetypes': ['erlang']}
2025-01-21 15:40:59,510 - INFO - Completion config: 50, detailing 0 candiates
127.0.0.1 - - [21/Jan/2025 15:40:59] "GET /signature_help_available?subserver=erlang HTTP/1.1" 200 23
2025-01-21 15:40:59,594 - DEBUG - Event name: BufferVisit
127.0.0.1 - - [21/Jan/2025 15:40:59] "POST /event_notification HTTP/1.1" 200 2
2025-01-21 15:40:59,597 - DEBUG - Event name: FileReadyToParse
2025-01-21 15:40:59,597 - INFO - Adding buffer identifiers for file: /tmp/test.erl
```

_Good_ code produces no warnings or errors via YCM;

```erl
-module(test).

-export([testy/0]).
testy() -> true.
```

Questionable code produces warnings;

```erl
-module(test).

questionable_idea() -> 'wat'.
```

> `/tmp/test.erl|3 col 1 warning| function questionable_idea/0 is unused`

Bad code pops the errors;

```erl
-module(test).

-export([bad_idea/0]).
bad_idea() -> 1 - Nan.
```

> `/tmp/test.erl|4 col 19 error| variable 'Nan' is unbound`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/lsp-examples/44)
<!-- Reviewable:end -->
