### PR TITLE
Add Postgre LS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ by YCM, though they should work for the most part.
    * [PHP](#php)
    * [Crystal](#crystal)
    * [Astro](#astro)
+   * [Postgres](#postgres)
    * [Known Issues](#known-issues)
 
 <!-- Added by: ben, at: Tue 21 Feb 2023 09:01:14 GMT -->
@@ -395,6 +396,13 @@ Finally, hopefully for now, adding the `@astrojs/ts-plugin` to your project's
   }
 }
 ```
+
+# Postgres
+
+Within the root of a project running `postgrestools init` is recommend by
+[Configuration](https://pgtools.dev/#configuration) documentation to create a
+`postgrestools.jsonc` file, then editing that file for your database setup
+seems required to make full use of this Language Server's tooling.
 
 # Jai
 

--- a/postgres/install.py
+++ b/postgres/install.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import subprocess, os, sys, platform
+
+def OnWindows():
+  return platform.system() == 'Windows'
+
+
+# On Windows, distutils.spawn.find_executable only works for .exe files
+# but .bat and .cmd files are also executables, so we use our own
+# implementation.
+def FindExecutable( executable ):
+  # Executable extensions used on Windows
+  WIN_EXECUTABLE_EXTS = [ '.exe', '.bat', '.cmd' ]
+
+  paths = os.environ[ 'PATH' ].split( os.pathsep )
+  base, extension = os.path.splitext( executable )
+
+  if OnWindows() and extension.lower() not in WIN_EXECUTABLE_EXTS:
+    extensions = WIN_EXECUTABLE_EXTS
+  else:
+    extensions = [ '' ]
+
+  for extension in extensions:
+    executable_name = executable + extension
+    if not os.path.isfile( executable_name ):
+      for path in paths:
+        executable_path = os.path.join( path, executable_name )
+        if os.path.isfile( executable_path ):
+          return executable_path
+    else:
+      return executable_name
+  return None
+
+
+def FindExecutableOrDie( executable, message ):
+  path = FindExecutable( executable )
+
+  if not path:
+    sys.exit( "ERROR: Unable to find executable '{0}'. {1}".format(
+      executable,
+      message ) )
+
+  return path
+
+
+def Main():
+  npm = FindExecutableOrDie( 'npm', 'npm is required to set up Postgre LS.' )
+  ## Note this is how we do because they use `"optionalDependencies"` under;
+  ##   ./node_modules/@postgrestools/postgrestools/package.json
+  ## ...  And `npm add` seems to auto-detect OS and architecture
+  subprocess.check_call( [ npm, 'add', '--save-dev', '--save-exact', '@postgrestools/postgrestools' ] )
+
+
+if __name__ == '__main__':
+  Main()

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -1,0 +1,3 @@
+{
+  "description": "ycmd postgres-ls runtime area"
+}

--- a/postgres/snippet.vim
+++ b/postgres/snippet.vim
@@ -1,0 +1,8 @@
+let g:ycm_language_server += [
+  \   {
+  \     'name': 'postgres',
+  \     'filetypes': [ 'sql' ],
+  \     'cmdline': [  expand( g:ycm_lsp_dir . '/postgres/node_modules/.bin/postgrestools' ), 'lsp-proxy' ],
+  \     'project_root_files': [ 'postgrestools.jsonc' ]
+  \   },
+  \ ]


### PR DESCRIPTION
:warning: using the `postgre/install.py` script to install/add `@postgrestools/postgrestools` NPM dev-dependency feels wrong, but also seems the easiest way of making NPM responsible for OS and architecture detection.

This means it might be wise to add a `.gitignore` to this sub directory to ignore the `package.json` file changes by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/lsp-examples/47)
<!-- Reviewable:end -->
