### PR TITLE
Update Julia snippet to match changes in the interface of `LanguageServer.jl`

### DIFF
--- a/julia/snippet.vim
+++ b/julia/snippet.vim
@@ -4,9 +4,8 @@ let s:julia_cmdline = ['julia', '--startup-file=no', '--history-file=no', '-e', 
 \       import StaticLint;
 \       import SymbolServer;
 \       env_path = dirname(Pkg.Types.Context().env.project_file);
-\       debug = false;
 \
-\       server = LanguageServer.LanguageServerInstance(stdin, stdout, debug, env_path, "", Dict());
+\       server = LanguageServer.LanguageServerInstance(stdin, stdout, env_path, "");
 \       server.runlinter = true;
 \       run(server);
 \   ']


### PR DESCRIPTION
This PR updates Julia's snippet for starting Julia's LSP server, as there are changes in the interface of instantiating of the server instance. The updated code is taken from the [repo of `LanguageServer.jl`](https://github.com/julia-vscode/LanguageServer.jl/wiki/Vim-and-Neovim).

Closes #50

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/lsp-examples/51)
<!-- Reviewable:end -->
