### PR TITLE
Fixed Ruby language installer for bundler versions >= 4.x.

### DIFF
--- a/ruby/install
+++ b/ruby/install
@@ -1,3 +1,12 @@
 #/usr/bin/env bash
 
-bundle install --path=vendor/bundle --binstubs
+bundler_version=$(bundle --version)
+bundler_major=${bundler_version%%.*}
+
+if (( bundler_major >= 4 )); then
+  bundle config set path 'vendor/bundle'
+  bundle install
+  bundle binstubs --all
+else
+  bundle install --path=vendor/bundle --binstubs
+fi

--- a/ruby/snippet.vim
+++ b/ruby/snippet.vim
@@ -1,7 +1,7 @@
 let g:ycm_language_server += [
   \   {
   \     'name': 'ruby',
-  \     'cmdline': [ expand( g:ycm_lsp_dir . '/ruby/bin/solargraph' ), 'stdio' ],
+  \     'cmdline': [ expand( g:ycm_lsp_dir .. '/ruby/bin/solargraph' ), 'stdio' ],
   \     'filetypes': [ 'ruby' ],
   \   },
   \ ]


### PR DESCRIPTION
As of at least bundler version 4.x the --path and --binstubs flags have been removed. This fix adapts the bundler invocation for the respective version being used.

Also, Vim deprecates the single-dot operator for string concatenation. Amended the Vim snippet for the Ruby language.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ycm-core/lsp-examples/56)
<!-- Reviewable:end -->
